### PR TITLE
Fix workflow: use full git history for merge operations

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # Need to fetch previous commit to compare
+          fetch-depth: 0  # Fetch full history for merging branches
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The auto-release workflow is failing with:
```
fatal: refusing to merge unrelated histories
```

This happens when trying to merge `main` back to `develop` after a release.

## Root Cause

The workflow uses `fetch-depth: 2` which only fetches the last 2 commits. When git tries to merge `main` into `develop`, it can't find a common ancestor within those 2 commits, so it treats them as unrelated histories.

## Solution

Change `fetch-depth: 2` to `fetch-depth: 0` to fetch full git history. This allows git to find the common ancestor and perform the merge successfully.

## Impact

- Fixes the broken merge-back-to-develop step in the release process
- Ensures future releases will automatically sync changes back to develop
- No impact on performance - the extra fetch time is negligible

## Testing

After merging this PR:
1. The workflow will run again (since this changes auto-release.yml)
2. It should successfully merge main to develop
3. develop will finally be synced with all the changes from v0.7.0 and earlier releases

Ref: https://github.com/whatisboom/boom-ui/actions/runs/21193218116/job/60963860730