### PR TITLE
Fix auto-release workflow to handle branch protection rules

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -183,14 +183,22 @@ jobs:
           git checkout develop
 
           # Try to merge main to develop
-          if git merge origin/main --no-ff -m "Merge main to develop after release ${{ steps.version-check.outputs.tag_name }}"; then
-            git push origin develop
-            echo "merge_status=success" >> $GITHUB_OUTPUT
-            echo "Successfully merged main to develop"
-          else
+          if ! git merge origin/main --no-ff -m "Merge main to develop after release ${{ steps.version-check.outputs.tag_name }}"; then
             echo "merge_status=conflict" >> $GITHUB_OUTPUT
             echo "Merge conflict detected"
             git merge --abort
+            exit 0
+          fi
+
+          # Merge succeeded, now try to push
+          if git push origin develop 2>&1 | tee push_output.log; then
+            echo "merge_status=success" >> $GITHUB_OUTPUT
+            echo "Successfully merged main to develop"
+          else
+            # Push failed - could be branch protection or other rules
+            echo "merge_status=push_failed" >> $GITHUB_OUTPUT
+            echo "Merge succeeded but push failed (likely branch protection rules)"
+            cat push_output.log
           fi
 
       - name: Delete release branch
@@ -204,44 +212,73 @@ jobs:
             echo "Branch $BRANCH already deleted, skipping"
           fi
 
-      - name: Create PR for conflicted merge
-        if: steps.version-check.outputs.version_changed == 'true' && steps.merge-to-develop.outputs.merge_status == 'conflict'
+      - name: Create PR for failed merge
+        if: steps.version-check.outputs.version_changed == 'true' && (steps.merge-to-develop.outputs.merge_status == 'conflict' || steps.merge-to-develop.outputs.merge_status == 'push_failed')
         uses: actions/github-script@v7
         with:
           script: |
             const branch = '${{ steps.source-branch.outputs.source_branch }}';
             const version = '${{ steps.version-check.outputs.current_version }}';
+            const mergeStatus = '${{ steps.merge-to-develop.outputs.merge_status }}';
 
-            const body = [
-              '## ⚠️ Merge Conflicts Detected',
-              '',
-              `This PR was automatically created because merging \`main\` to \`develop\` after release resulted in conflicts.`,
-              '',
-              `**Release:** v${version}`,
-              `**Source branch:** \`${branch}\` (already merged to \`main\`)`,
-              `**Merging:** \`main\` → \`develop\``,
-              '',
-              '### What happened',
-              `1. ✅ Release v${version} was successfully merged to \`main\``,
-              `2. ✅ Tag v${version} was created`,
-              '3. ✅ Published to npm',
-              '4. ❌ Automatic merge of `main` to `develop` failed due to conflicts',
-              '',
-              '### Next steps',
-              '1. Resolve the merge conflicts in this PR',
-              '2. Merge this PR to `develop`',
-              `3. The \`${branch}\` branch will be automatically deleted after merge`,
-              '',
-              '**Note:** This PR uses the release branch as a proxy to merge changes from \`main\` back to \`develop\`.'
-            ].join('\n');
-
+            let title, body;
             const tagName = '${{ steps.version-check.outputs.tag_name }}';
+
+            if (mergeStatus === 'conflict') {
+              title = `Merge main to develop after ${tagName} (conflicts)`;
+              body = [
+                '## ⚠️ Merge Conflicts Detected',
+                '',
+                `This PR was automatically created because merging \`main\` to \`develop\` after release resulted in conflicts.`,
+                '',
+                `**Release:** v${version}`,
+                `**Source branch:** \`${branch}\` (already merged to \`main\`)`,
+                `**Merging:** \`main\` → \`develop\``,
+                '',
+                '### What happened',
+                `1. ✅ Release v${version} was successfully merged to \`main\``,
+                `2. ✅ Tag v${version} was created`,
+                '3. ✅ Published to npm',
+                '4. ❌ Automatic merge of `main` to `develop` failed due to conflicts',
+                '',
+                '### Next steps',
+                '1. Resolve the merge conflicts in this PR',
+                '2. Merge this PR to `develop`',
+                `3. The \`${branch}\` branch will be automatically deleted after merge`,
+                '',
+                '**Note:** This PR uses the release branch as a proxy to merge changes from \`main\` back to \`develop\`.'
+              ].join('\n');
+            } else {
+              title = `Merge main to develop after ${tagName}`;
+              body = [
+                '## 🔒 Branch Protection Rules Prevent Direct Push',
+                '',
+                `This PR was automatically created because the \`develop\` branch has protection rules that prevent direct pushes.`,
+                '',
+                `**Release:** v${version}`,
+                `**Merging:** \`main\` → \`develop\``,
+                '',
+                '### What happened',
+                `1. ✅ Release v${version} was successfully merged to \`main\``,
+                `2. ✅ Tag v${version} was created`,
+                '3. ✅ Published to npm',
+                '4. ✅ Merge of `main` to `develop` succeeded locally',
+                '5. ❌ Push to `develop` was blocked by branch protection rules',
+                '',
+                '### Next steps',
+                '1. Review this PR (should be clean, no conflicts)',
+                '2. Merge this PR to `develop`',
+                `3. The \`${branch}\` branch will be automatically deleted`,
+                '',
+                '**Note:** This is expected when `develop` has branch protection rules requiring PRs.'
+              ].join('\n');
+            }
 
             await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Merge main to develop after ${tagName} (conflicts)`,
-              head: branch,
+              title: title,
+              head: 'main',
               base: 'develop',
               body: body
             });
@@ -271,9 +308,14 @@ jobs:
 
             if (pr) {
               let statusEmoji = mergeStatus === 'success' ? '✅' : '⚠️';
-              let mergeMessage = mergeStatus === 'success'
-                ? `Successfully merged \`main\` to \`develop\` and deleted \`${sourceBranch}\``
-                : `Merge of \`main\` to \`develop\` had conflicts. Created PR for manual resolution.`;
+              let mergeMessage;
+              if (mergeStatus === 'success') {
+                mergeMessage = `Successfully merged \`main\` to \`develop\` and deleted \`${sourceBranch}\``;
+              } else if (mergeStatus === 'push_failed') {
+                mergeMessage = `Merge succeeded but push was blocked by branch protection rules. Created PR for manual merge.`;
+              } else {
+                mergeMessage = `Merge of \`main\` to \`develop\` had conflicts. Created PR for manual resolution.`;
+              }
 
               const commentBody = [
                 '## 🚀 Release Automation Complete',


### PR DESCRIPTION
## Summary
Fixes the auto-release workflow to properly handle cases where the \`develop\` branch has protection rules that prevent direct pushes.

## Problem
The workflow previously only handled merge conflicts. When the merge succeeded locally but the push failed due to branch protection rules, the workflow would exit with an error without creating a PR.

From failed workflow run for v0.7.1:
```
remote: error: GH013: Repository rule violations found for refs/heads/develop.
remote: - Changes must be made through a pull request.
remote: - This branch must not contain merge commits.
error: failed to push some refs to 'https://github.com/whatisboom/boom-ui'
```

## Changes
- Separate merge and push operations in merge-to-develop step
- Detect push failures and set \`merge_status=push_failed\`
- Create PR when push fails due to branch protection (not just conflicts)
- Update PR creation to handle both \`conflict\` and \`push_failed\` cases
- Update comment on original PR to show correct status for all cases

## Testing
After this PR is merged, the next release will automatically create a PR when trying to merge main → develop, instead of failing.

## Related
- Fixes workflow failure from PR #77 (Release v0.7.1)
- Will enable proper gitflow automation with branch protection enabled