### PR TITLE
Adjust theme HSL values for warmer color palette

### DIFF
--- a/src/styles/tokens/palettes.css
+++ b/src/styles/tokens/palettes.css
@@ -14,24 +14,24 @@
      ========================================================================== */
 
   /* Base - Neutral colors for backgrounds, text, borders */
-  --boom-hue-base: 210;
+  --boom-hue-base: 45;
 
   /* Accent - Primary brand color for interactive elements */
-  --boom-hue-accent: 215;
+  --boom-hue-accent: 210;
 
   /* Semantic state colors */
   --boom-hue-success: 142;   /* green */
   --boom-hue-warning: 38;    /* amber */
   --boom-hue-error: 0;       /* red */
-  --boom-hue-info: 189;      /* teal */
+  --boom-hue-info: 210;      /* blue */
 
   /* ==========================================================================
      SATURATION & LIGHTNESS VARIABLES - Advanced Theme Customization
      ========================================================================== */
 
   /* Base - Neutral saturation/lightness (reference: base-500) */
-  --boom-sat-base: 13;
-  --boom-light-base: 66;
+  --boom-sat-base: 5;
+  --boom-light-base: 30;
 
   /* Accent - Primary brand saturation/lightness (reference: accent-500) */
   --boom-sat-accent: 47;
@@ -49,9 +49,9 @@
   --boom-sat-error: 84;
   --boom-light-error: 60;
 
-  /* Info - Teal saturation/lightness (reference: info-500) */
-  --boom-sat-info: 80;
-  --boom-light-info: 39;
+  /* Info - Blue saturation/lightness (reference: info-500) */
+  --boom-sat-info: 60;
+  --boom-light-info: 34;
 
   /* ==========================================================================
      DARK THEME (Default)
@@ -139,12 +139,12 @@
 
 :root[data-theme='light'] {
   /* Override HSL variables for light theme */
-  --boom-hue-base: 210;
-  --boom-sat-base: 2;
-  --boom-light-base: 50;
+  --boom-hue-base: 45;
+  --boom-sat-base: 10;
+  --boom-light-base: 40;
   --boom-hue-accent: 210;
-  --boom-sat-accent: 100;
-  --boom-light-accent: 55;
+  --boom-sat-accent: 40;
+  --boom-light-accent: 57;
   --boom-hue-success: 142;
   --boom-sat-success: 63;
   --boom-light-success: 51;
@@ -154,9 +154,9 @@
   --boom-hue-error: 0;
   --boom-sat-error: 84;
   --boom-light-error: 60;
-  --boom-hue-info: 189;
-  --boom-sat-info: 80;
-  --boom-light-info: 52;
+  --boom-hue-info: 210;
+  --boom-sat-info: 60;
+  --boom-light-info: 62;
 
   /* Base - Neutral colors inverted from dark theme */
   --boom-palette-base-50: hsl(0 0% 100%);


### PR DESCRIPTION
## Summary
- Updates HSL color values in both dark and light themes
- Shifts base colors from blue-gray (hue 210) to warm gray/tan (hue 45)
- Adjusts saturation and lightness values for better contrast and visual balance
- Aligns info color with accent color (both hue 210)

## Changes
**Dark theme:**
- Base: hue 210→45, sat 13→5, light 66→30 (warmer, less saturated, darker)
- Accent: hue 215→210 (slightly bluer)
- Info: hue 189→210, sat 80→60, light 39→34 (bluer, less saturated, darker)

**Light theme:**
- Base: hue 210→45, sat 2→10, light 50→40 (warmer, more saturated, darker)
- Accent: sat 100→40, light 55→57 (less vibrant, slightly lighter)
- Info: hue 189→210, light 52→62 (bluer, lighter)

## Test Plan
- [x] Type checking passes
- [x] Linting passes
- [x] Build succeeds
- [x] All tests pass
- [x] Accessibility tests pass (vitest-axe)

## Files Changed
- `src/styles/tokens/palettes.css` - HSL variable updates only