### PR TITLE
Fix git push exit code detection in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -173,6 +173,7 @@ jobs:
       - name: Merge main to develop
         if: steps.version-check.outputs.version_changed == 'true' && steps.tag-check.outputs.tag_exists == 'false' && steps.source-branch.outputs.source_branch != ''
         id: merge-to-develop
+        shell: bash
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -202,7 +203,6 @@ jobs:
             # Push failed - could be branch protection or other rules
             echo "merge_status=push_failed" >> $GITHUB_OUTPUT
             echo "Merge succeeded but push failed (likely branch protection rules)"
-            cat push_output.log
           fi
 
       - name: Delete release branch

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -191,7 +191,11 @@ jobs:
           fi
 
           # Merge succeeded, now try to push
-          if git push origin develop 2>&1 | tee push_output.log; then
+          # Capture push output and exit code separately to avoid pipeline exit code masking
+          git push origin develop 2>&1 | tee push_output.log
+          PUSH_EXIT_CODE=${PIPESTATUS[0]}
+
+          if [ $PUSH_EXIT_CODE -eq 0 ]; then
             echo "merge_status=success" >> $GITHUB_OUTPUT
             echo "Successfully merged main to develop"
           else


### PR DESCRIPTION
## Problem

The auto-release workflow had a critical bug that prevented it from correctly detecting when `git push origin develop` failed due to branch protection rules.

### Root Cause

Lines 194-202 used this pattern:
```bash
if git push origin develop 2>&1 | tee push_output.log; then
  echo "merge_status=success" >> $GITHUB_OUTPUT
```

When using pipes, the shell's `$?` exit code comes from the last command in the pipeline (`tee`), not the first (`git push`). Since `tee` always succeeds, the workflow incorrectly reported success even when the push was rejected by GitHub.

### Impact in v0.7.2

1. ✅ Merge succeeded locally
2. ❌ Push to develop was rejected (branch protection: requires PRs + no merge commits)
3. ❌ Workflow incorrectly set `merge_status=success`
4. ❌ No PR was auto-created (only happens when status is 'conflict' or 'push_failed')
5. ❌ Release branch was deleted (because it thought merge succeeded)
6. ❌ Commits from main are missing on develop

## Solution

Capture the exit code of `git push` using `${PIPESTATUS[0]}` before checking it:

```bash
git push origin develop 2>&1 | tee push_output.log
PUSH_EXIT_CODE=${PIPESTATUS[0]}

if [ $PUSH_EXIT_CODE -eq 0 ]; then
  echo "merge_status=success" >> $GITHUB_OUTPUT
else
  echo "merge_status=push_failed" >> $GITHUB_OUTPUT
```

This ensures the workflow correctly:
- Detects when push to develop fails
- Sets `merge_status=push_failed` appropriately
- Triggers auto-PR creation for manual conflict resolution
- Prevents premature deletion of release branches

## Testing

The fix will be validated on the next release (v0.7.3 or v0.8.0) by observing that:
- Push failure is detected correctly
- Auto-PR is created with proper messaging
- Release branch is preserved until conflicts are resolved

## Related

A separate PR will sync develop with main to restore the missing v0.7.2 commits.